### PR TITLE
use GCC version 13.2.0 (same as SGDK GCC on Windows)

### DIFF
--- a/tool-variables
+++ b/tool-variables
@@ -6,7 +6,7 @@ GDK_VERSION="master"
 #GDK_VERSION="v2.11" # use this for tagged releases
 
 GCC_MIRROR="https://mirrors.ocf.berkeley.edu/gnu"
-GCC_VERSION="14.2.0"
+GCC_VERSION="13.2.0"
 GCC_DIR="gcc-${GCC_VERSION}"
 GCC_FILE="${GCC_DIR}.tar.gz"
 GCC_URL="${GCC_MIRROR}/gcc/${GCC_DIR}/$GCC_FILE"


### PR DESCRIPTION
The GCC that ships with the SGDK on Windows is version 13.2.0.
The m68k-elf-gcc generated by this toolchain is version 14.2.0.

This is not a problem if all of the developers working on a given game project are on Linux or Mac, but when working on a game project that involves developers that are spread across Windows and Linux/Mac, then this becomes a problem, due to the fact these GCC versions do not behave the same, so the project could build on one platform, but not on the other.

This change aims to reduce the differences across platforms by ensuring the GCC version is the same across all OSes.